### PR TITLE
Update Field defaults upon Form receiving new props

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -16,6 +16,7 @@ class Form extends Component {
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.updateDefaults = this.updateDefaults.bind(this);
   }
 
   /**
@@ -23,7 +24,15 @@ class Form extends Component {
    * the state with the value of that field.
    */
   componentWillMount() {
-    this.props.fields
+    this.updateDefaults(this.props.fields);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.updateDefaults(nextProps.fields);
+  }
+
+  updateDefaults(fields) {
+    fields
       .filter(field => field.defaultValue)
       .forEach(field => {
         return this.setState({


### PR DESCRIPTION
Currently, Forms will only set default values for Fields upon mounting. There are use cases in which these default values could change, so this PR applies the same logic to `onComponentWillReceiveProps`.
